### PR TITLE
DRY-ify humanized amounts + Add "scaleUp" + Fix tokenA decimals

### DIFF
--- a/src/entities/action.ts
+++ b/src/entities/action.ts
@@ -13,7 +13,7 @@ import {
 } from "@types";
 
 import { ActionType } from "../constants/globals";
-import { expect, zero } from "../utils";
+import { expect, humanize, zero } from "../utils";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
@@ -308,9 +308,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenA!),
-          humanized: new BigNumber(this.inputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-          ),
+          humanized: humanize(this.inputTokenA!, this.option!.pool!.tokenA!.decimals),
         };
 
         return value;
@@ -322,9 +320,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenA!),
-          humanized: new BigNumber(this.inputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.underlying!.decimals)
-          ),
+          humanized: humanize(this.inputTokenA!, this.option!.underlying!.decimals),
         };
 
         return value;
@@ -346,9 +342,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenA!),
-          humanized: new BigNumber(this.inputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-          ),
+          humanized: humanize(this.inputTokenA!, this.option!.pool!.tokenA!.decimals),
         };
 
         return value;
@@ -360,9 +354,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenA!),
-          humanized: new BigNumber(this.inputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.collateral!.decimals)
-          ),
+          humanized: humanize(this.inputTokenA!, this.option!.collateral!.decimals),
         };
 
         return value;
@@ -386,9 +378,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenB!),
-          humanized: new BigNumber(this.inputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-          ),
+          humanized: humanize(this.inputTokenB!, this.option!.pool!.tokenB!.decimals),
         };
 
         return value;
@@ -399,9 +389,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenB!),
-          humanized: new BigNumber(this.inputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.strike!.decimals)
-          ),
+          humanized: humanize(this.inputTokenB!, this.option!.strike!.decimals),
         };
 
         return value;
@@ -415,9 +403,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenB!),
-          humanized: new BigNumber(this.inputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-          ),
+          humanized: humanize(this.inputTokenB!, this.option!.pool!.tokenB!.decimals),
         };
 
         return value;
@@ -426,9 +412,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.inputTokenB!),
-          humanized: new BigNumber(this.inputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.strike!.decimals)
-          ),
+          humanized: humanize(this.inputTokenB!, this.option!.strike!.decimals),
         };
 
         return value;
@@ -458,9 +442,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenA!),
-          humanized: new BigNumber(this.outputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-          ),
+          humanized: humanize(this.outputTokenA!, this.option!.pool!.tokenA!.decimals),
         };
 
         return value;
@@ -472,9 +454,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenA!),
-          humanized: new BigNumber(this.outputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.underlying!.decimals)
-          ),
+          humanized: humanize(this.outputTokenA!, this.option!.underlying!.decimals),
         };
 
         return value;
@@ -495,9 +475,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenA!),
-          humanized: new BigNumber(this.outputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-          ),
+          humanized: humanize(this.outputTokenA!, this.option!.pool!.tokenA!.decimals),
         };
 
         return value;
@@ -513,9 +491,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenA!),
-          humanized: new BigNumber(this.outputTokenA!).dividedBy(
-            new BigNumber(10).pow(this.option!.collateral!.decimals)
-          ),
+          humanized: humanize(this.outputTokenA!, this.option!.collateral!.decimals),
         };
 
         return value;
@@ -537,9 +513,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenB!),
-          humanized: new BigNumber(this.outputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-          ),
+          humanized: humanize(this.outputTokenB!, this.option!.pool!.tokenB!.decimals),
         };
 
         return value;
@@ -556,9 +530,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenB!),
-          humanized: new BigNumber(this.outputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.strike!.decimals)
-          ),
+          humanized: humanize(this.outputTokenB!, this.option!.strike!.decimals),
         };
 
         return value;
@@ -572,9 +544,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenB!),
-          humanized: new BigNumber(this.outputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-          ),
+          humanized: humanize(this.outputTokenB!, this.option!.pool!.tokenB!.decimals),
         };
 
         return value;
@@ -587,9 +557,7 @@ export default class Action implements IAction {
 
         const value: IValue = {
           raw: new BigNumber(this.outputTokenB!),
-          humanized: new BigNumber(this.outputTokenB!).dividedBy(
-            new BigNumber(10).pow(this.option!.strike!.decimals)
-          ),
+          humanized: humanize(this.outputTokenB!, this.option!.strike!.decimals),
         };
 
         return value;
@@ -609,9 +577,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.metadataOptionsMintedAndSold!),
-      humanized: new BigNumber(this.metadataOptionsMintedAndSold!).dividedBy(
-        new BigNumber(10).pow(this.option!.decimals!)
-      ),
+      humanized: humanize(this.metadataOptionsMintedAndSold!, this.option!.decimals),
     };
 
     return value;
@@ -627,9 +593,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.metadataFeeAValue!),
-      humanized: new BigNumber(this.metadataFeeAValue!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.metadataFeeAValue!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -645,9 +609,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.metadataFeeBValue!),
-      humanized: new BigNumber(this.metadataFeeBValue!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.metadataFeeBValue!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -663,9 +625,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.spotPrice!),
-      humanized: new BigNumber(this.spotPrice!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.spotPrice!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -681,9 +641,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextSellingPrice!),
-      humanized: new BigNumber(this.nextSellingPrice!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextSellingPrice!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -699,9 +657,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextBuyingPrice!),
-      humanized: new BigNumber(this.nextBuyingPrice!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextBuyingPrice!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -720,9 +676,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextDynamicSellingPrice!),
-      humanized: new BigNumber(this.nextDynamicSellingPrice!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextDynamicSellingPrice!, this.option!.pool!.tokenB!.decimals)
     };
 
     return value;
@@ -738,9 +692,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextDynamicBuyingPrice!),
-      humanized: new BigNumber(this.nextDynamicBuyingPrice!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextDynamicBuyingPrice!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -759,9 +711,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextUserTokenALiquidity!),
-      humanized: new BigNumber(this.nextUserTokenALiquidity!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(this.nextUserTokenALiquidity!, this.option!.pool!.tokenA!.decimals),
     };
 
     return value;
@@ -780,9 +730,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextUserTokenBLiquidity!),
-      humanized: new BigNumber(this.nextUserTokenBLiquidity!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextUserTokenBLiquidity!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -798,9 +746,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextTBA!),
-      humanized: new BigNumber(this.nextTBA!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(this.nextTBA!, this.option!.pool!.tokenA!.decimals),
     };
 
     return value;
@@ -816,9 +762,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextTBB!),
-      humanized: new BigNumber(this.nextTBB!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextTBB!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -834,9 +778,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextDBA!),
-      humanized: new BigNumber(this.nextDBA!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(this.nextDBA!, this.option!.pool!.tokenA!.decimals),
     };
 
     return value;
@@ -852,9 +794,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextDBB!),
-      humanized: new BigNumber(this.nextDBB!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextDBB!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -874,9 +814,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextFeesA!),
-      humanized: new BigNumber(this.nextFeesA!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextFeesA!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;
@@ -896,9 +834,7 @@ export default class Action implements IAction {
 
     const value: IValue = {
       raw: new BigNumber(this.nextFeesB!),
-      humanized: new BigNumber(this.nextFeesB!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(this.nextFeesB!, this.option!.pool!.tokenB!.decimals),
     };
 
     return value;

--- a/src/entities/helper.ts
+++ b/src/entities/helper.ts
@@ -9,7 +9,7 @@ import {
   ITransactionError,
   Optional,
 } from "@types";
-import { expect, getDefaultDeadline, getOverrides } from "../utils";
+import { expect, getDefaultDeadline, getOverrides, scaleUp } from "../utils";
 import contracts from "../contracts";
 import { ALLOW_LOGS } from "../constants/globals";
 
@@ -63,12 +63,8 @@ export default class Helper implements IHelper {
     expect(optionAmount, "optionAmount", "object");
     expect(premiumAmount, "premiumAmount", "object");
 
-    const input = new BigNumber(premiumAmount).multipliedBy(
-      new BigNumber(10).pow(option.pool!.tokenB!.decimals)
-    );
-    const output = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
+    const input = scaleUp(premiumAmount, option.pool!.tokenB!.decimals);
+    const output = scaleUp(optionAmount, option.decimals!);
 
     const IV = await option.pool!.getIV({ provider: this.provider });
 
@@ -122,12 +118,8 @@ export default class Helper implements IHelper {
     expect(optionAmount, "optionAmount", "object");
     expect(premiumAmount, "premiumAmount", "object");
 
-    const input = new BigNumber(premiumAmount).multipliedBy(
-      new BigNumber(10).pow(option.pool!.tokenB!.decimals)
-    );
-    const output = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
+    const input = scaleUp(premiumAmount, option.pool!.tokenB!.decimals);
+    const output = scaleUp(optionAmount, option.decimals!);
 
     const IV = await option.pool!.getIV({ provider: this.provider });
 
@@ -189,13 +181,8 @@ export default class Helper implements IHelper {
     expect(optionAmount, "optionAmount", "object");
     expect(premiumAmount, "premiumAmount", "object");
 
-    const input = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
-
-    const output = new BigNumber(premiumAmount).multipliedBy(
-      new BigNumber(10).pow(option.pool!.tokenB!.decimals)
-    );
+    const input = scaleUp(optionAmount, option.decimals!);
+    const output = scaleUp(premiumAmount, option.pool!.tokenB!.decimals);
 
     const IV = await option.pool!.getIV({ provider: this.provider });
 
@@ -250,13 +237,8 @@ export default class Helper implements IHelper {
     expect(optionAmount, "optionAmount", "object");
     expect(premiumAmount, "premiumAmount", "object");
 
-    const input = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
-
-    const output = new BigNumber(premiumAmount).multipliedBy(
-      new BigNumber(10).pow(option.pool!.tokenB!.decimals)
-    );
+    const input = scaleUp(optionAmount, option.decimals!);
+    const output = scaleUp(premiumAmount, option.pool!.tokenB!.decimals);
 
     const IV = await option.pool!.getIV({ provider: this.provider });
 
@@ -361,13 +343,8 @@ export default class Helper implements IHelper {
     expect(tokenAAmount, "tokenAAmount", "object");
     expect(tokenBAmount, "tokenBAmount", "object");
 
-    const amountA = new BigNumber(tokenAAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
-
-    const amountB = new BigNumber(tokenBAmount).multipliedBy(
-      new BigNumber(10).pow(option.pool!.tokenB!.decimals)
-    );
+    const amountA = scaleUp(tokenAAmount, option.decimals!);
+    const amountB = scaleUp(tokenBAmount, option.pool!.tokenB!.decimals);
 
     const contract = contracts.instances.optionHelper(
       this.signer!,
@@ -417,9 +394,7 @@ export default class Helper implements IHelper {
         "Adding liquidity with a single asset is not allowed for calls."
       );
 
-    const amountB = new BigNumber(tokenBAmount).multipliedBy(
-      new BigNumber(10).pow(option.pool!.tokenB!.decimals)
-    );
+    const amountB = scaleUp(tokenBAmount, option.pool!.tokenB!.decimals);
 
     const contract = contracts.instances.optionHelper(
       this.signer!,
@@ -468,13 +443,8 @@ export default class Helper implements IHelper {
     expect(tokenAAmount, "tokenAAmount", "object");
     expect(tokenBAmount, "tokenBAmount", "object");
 
-    const amountA = new BigNumber(tokenAAmount).multipliedBy(
-      new BigNumber(10).pow(option.collateral!.decimals!)
-    );
-
-    const amountB = new BigNumber(tokenBAmount).multipliedBy(
-      new BigNumber(10).pow(option.pool!.tokenB!.decimals)
-    );
+    const amountA = scaleUp(tokenAAmount, option.collateral!.decimals!);
+    const amountB = scaleUp(tokenBAmount, option.pool!.tokenB!.decimals);
 
     const contract = contracts.instances.optionHelper(
       this.signer!,
@@ -523,9 +493,8 @@ export default class Helper implements IHelper {
         "Minting from the Option Helper with utility tokens (e.g. ETH, MATIC) is not allowed for calls. Please interact with the option contract itself."
       );
 
-    const output = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
+    const output = scaleUp(optionAmount, option.decimals!);
+    
 
     const contract = contracts.instances.optionHelper(
       this.signer!,
@@ -565,9 +534,7 @@ export default class Helper implements IHelper {
 
     const contract = contracts.instances.option(this.signer!, option.address);
 
-    const input = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
+    const input = scaleUp(optionAmount, option.decimals!);
 
     const args = [input.toFixed(0).toString()];
 
@@ -600,9 +567,7 @@ export default class Helper implements IHelper {
     expect(option.decimals, "decimals");
     expect(optionAmount, "optionAmount", "object");
 
-    const input = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
+    const input = scaleUp(optionAmount, option.decimals!);
 
     const contract = contracts.instances.option(this.signer!, option.address);
 
@@ -638,9 +603,7 @@ export default class Helper implements IHelper {
     expect(option.decimals, "decimals");
     expect(optionAmount, "optionAmount", "object");
 
-    const input = new BigNumber(optionAmount).multipliedBy(
-      new BigNumber(10).pow(option.decimals!)
-    );
+    const input = scaleUp(optionAmount, option.decimals!);
 
     const contract = contracts.instances.option(this.signer!, option.address);
 

--- a/src/entities/multicall/aggregator.ts
+++ b/src/entities/multicall/aggregator.ts
@@ -20,7 +20,7 @@ import {
 } from "@types";
 
 import { ALLOW_LOGS } from "../../constants/globals";
-import { expect, zero } from "../../utils";
+import { expect, humanize, zero } from "../../utils";
 
 import MulticallParser from "./parser";
 import MulticallEngine from "./engine";
@@ -251,9 +251,7 @@ export default class MulticallAggregator {
         if (includePool !== false) {
           expect(option?.pool?.tokenA, "option pool tokenA");
           const pool = option.pool!;
-          const one = new BigNumber(1).times(
-            new BigNumber(10).pow(pool!.tokenA!.decimals)
-          );
+          const one = new BigNumber(10).pow(pool!.tokenA!.decimals)
 
           const poolInstructions: CallContext = MulticallParser.instructions(
             `p-${option.address!}`,
@@ -945,17 +943,13 @@ export default class MulticallAggregator {
           const userFeeWithdrawAmountA: IValue = {
             label: "Fee amounts redeemable for user shares for side A",
             raw: new BigNumber(amountA),
-            humanized: new BigNumber(amountA).dividedBy(
-              new BigNumber(10).pow(option!.pool!.tokenB!.decimals!)
-            ),
+            humanized: humanize(new BigNumber(amountA), option!.pool!.tokenA!.decimals),
           };
 
           const userFeeWithdrawAmountB: IValue = {
             label: "Fee amounts redeemable for user shares for side B",
             raw: new BigNumber(amountB),
-            humanized: new BigNumber(amountB).dividedBy(
-              new BigNumber(10).pow(option!.pool!.tokenB!.decimals!)
-            ),
+            humanized: humanize(new BigNumber(amountB), option!.pool!.tokenB!.decimals),
           };
 
           return {

--- a/src/entities/multicall/aggregator.ts
+++ b/src/entities/multicall/aggregator.ts
@@ -943,7 +943,7 @@ export default class MulticallAggregator {
           const userFeeWithdrawAmountA: IValue = {
             label: "Fee amounts redeemable for user shares for side A",
             raw: new BigNumber(amountA),
-            humanized: humanize(new BigNumber(amountA), option!.pool!.tokenA!.decimals),
+            humanized: humanize(new BigNumber(amountA), option!.pool!.tokenB!.decimals),
           };
 
           const userFeeWithdrawAmountB: IValue = {

--- a/src/entities/multicall/parser.ts
+++ b/src/entities/multicall/parser.ts
@@ -51,7 +51,7 @@ export default class Parser {
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA),
-        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenA!.decimals)
+        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenB!.decimals)
       };
 
       const feesB: IValue = {
@@ -99,7 +99,7 @@ export default class Parser {
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA),
-        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenA!.decimals)
+        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenB!.decimals)
       };
 
       const feesB: IValue = {
@@ -344,7 +344,7 @@ export default class Parser {
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA),
-        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenA!.decimals)
+        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenB!.decimals)
       };
 
       const feesB: IValue = {

--- a/src/entities/multicall/parser.ts
+++ b/src/entities/multicall/parser.ts
@@ -10,7 +10,7 @@ import {
 import { IOption, IPool, IValue } from "@types";
 
 import { ALLOW_LOGS, ALLOW_LOGS_LVL2 } from "../../constants/globals";
-import { expect, zero } from "../../utils";
+import { expect, humanize, zero } from "../../utils";
 
 export default class Parser {
   /**
@@ -46,23 +46,17 @@ export default class Parser {
 
       const value: IValue = {
         raw: new BigNumber(amountBIn),
-        humanized: new BigNumber(amountBIn).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(amountBIn), pool!.tokenB!.decimals)
       };
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA),
-        humanized: new BigNumber(feesTokenA).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenA!.decimals)
       };
 
       const feesB: IValue = {
         raw: new BigNumber(feesTokenB),
-        humanized: new BigNumber(feesTokenB).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenB), pool!.tokenB!.decimals)
       };
 
       return { value, feesA, feesB };
@@ -100,23 +94,17 @@ export default class Parser {
 
       const value: IValue = {
         raw: new BigNumber(amountBOut),
-        humanized: new BigNumber(amountBOut).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(amountBOut), pool!.tokenB!.decimals)
       };
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA),
-        humanized: new BigNumber(feesTokenA).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenA!.decimals)
       };
 
       const feesB: IValue = {
         raw: new BigNumber(feesTokenB),
-        humanized: new BigNumber(feesTokenB).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenB), pool!.tokenB!.decimals)
       };
 
       return { value, feesA, feesB };
@@ -150,17 +138,13 @@ export default class Parser {
       const TBA: IValue = {
         label: "TBA",
         raw: new BigNumber(rTBA),
-        humanized: new BigNumber(rTBA).dividedBy(
-          new BigNumber(10).pow(pool!.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber(rTBA), pool!.tokenA!.decimals)
       };
 
       const TBB: IValue = {
         label: "TBB",
         raw: new BigNumber(rTBB),
-        humanized: new BigNumber(rTBB).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(rTBB), pool!.tokenB!.decimals)
       };
 
       return [TBA, TBB];
@@ -202,16 +186,12 @@ export default class Parser {
       const UBA: IValue = {
         label: "Balance tokenA",
         raw: new BigNumber(rUBA),
-        humanized: new BigNumber(rUBA).dividedBy(
-          new BigNumber(10).pow(pool.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber(rUBA), pool!.tokenA!.decimals)
       };
       const UBB: IValue = {
         label: "Balance tokenB",
         raw: new BigNumber(rUBB),
-        humanized: new BigNumber(rUBB).dividedBy(
-          new BigNumber(10).pow(pool.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(rUBB), pool!.tokenB!.decimals)
       };
 
       return [UBA, UBB];
@@ -252,17 +232,13 @@ export default class Parser {
       const SB: IValue = {
         label: "Balance token",
         raw: new BigNumber(rSB),
-        humanized: new BigNumber(rSB).dividedBy(
-          new BigNumber(10).pow(option.strike!.decimals)
-        ),
+        humanized: humanize(new BigNumber(rSB), option!.strike!.decimals)
       };
 
       const UB: IValue = {
         label: "Balance underlying",
         raw: new BigNumber(rUB),
-        humanized: new BigNumber(rUB).dividedBy(
-          new BigNumber(10).pow(option.underlying!.decimals)
-        ),
+        humanized: humanize(new BigNumber(rUB), option!.underlying!.decimals)
       };
 
       return [UB, SB];
@@ -294,9 +270,7 @@ export default class Parser {
       const value: IValue = {
         label: "Balance option tokens",
         raw: new BigNumber(amount),
-        humanized: new BigNumber(amount).dividedBy(
-          new BigNumber(10).pow(option.decimals!)
-        ),
+        humanized: humanize(new BigNumber(amount), option!.decimals)
       };
 
       return value;
@@ -328,9 +302,7 @@ export default class Parser {
       const value: IValue = {
         label: "Balance option tokens in wallet",
         raw: new BigNumber(amount),
-        humanized: new BigNumber(amount).dividedBy(
-          new BigNumber(10).pow(option.decimals!)
-        ),
+        humanized: humanize(new BigNumber(amount), option!.decimals)
       };
 
       return value;
@@ -367,37 +339,27 @@ export default class Parser {
 
       const value: IValue = {
         raw: new BigNumber(amount),
-        humanized: new BigNumber(amount).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(amount), pool!.tokenB!.decimals)
       };
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA),
-        humanized: new BigNumber(feesTokenA).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenA), pool!.tokenA!.decimals)
       };
 
       const feesB: IValue = {
         raw: new BigNumber(feesTokenB),
-        humanized: new BigNumber(feesTokenB).dividedBy(
-          new BigNumber(10).pow(pool!.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenB), pool!.tokenB!.decimals)
       };
 
       const surplus: IValue = {
         raw: new BigNumber((_context.surplus as string) || 0),
-        humanized: new BigNumber((_context.surplus as string) || 0).dividedBy(
-          new BigNumber(10).pow(pool!.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber((_context.surplus as string) || 0), pool!.tokenA!.decimals)
       };
 
       const shortage: IValue = {
         raw: new BigNumber((_context.shortage as string) || 0),
-        humanized: new BigNumber((_context.shortage as string) || 0).dividedBy(
-          new BigNumber(10).pow(pool!.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber((_context.shortage as string) || 0), pool!.tokenA!.decimals)
       };
 
       const context = {
@@ -441,9 +403,7 @@ export default class Parser {
       const value: IValue = {
         label,
         raw: new BigNumber(amount),
-        humanized: new BigNumber(amount).dividedBy(
-          new BigNumber(10).pow(decimals!)
-        ),
+        humanized: humanize(new BigNumber(amount), decimals)
       };
 
       return value;

--- a/src/entities/option.ts
+++ b/src/entities/option.ts
@@ -21,7 +21,7 @@ import {
   MILESTONE_EXPIRATION_SOON,
   ALLOW_LOGS,
 } from "../constants/globals";
-import { expect, zero } from "../utils";
+import { expect, humanize, zero } from "../utils";
 import contracts from "../contracts";
 import Token from "./token";
 
@@ -208,9 +208,7 @@ export default class Option implements IOption {
 
     this.strikePrice = {
       raw: params.strikePrice,
-      humanized: new BigNumber(params.strikePrice).dividedBy(
-        new BigNumber(10).pow(this.strike!.decimals)
-      ),
+      humanized: humanize(new BigNumber(params.strikePrice), this.strike!.decimals)
     };
 
     this.expiration = new BigNumber(params.expiration).toNumber();
@@ -224,9 +222,7 @@ export default class Option implements IOption {
 
     this.seriesFeeVolume = {
       raw: params.seriesFeeVolume,
-      humanized: new BigNumber(params.seriesFeeVolume).dividedBy(
-        new BigNumber(10).pow(this.strike!.decimals)
-      ),
+      humanized: humanize(new BigNumber(params.seriesFeeVolume), this.strike!.decimals)
     };
 
     return this as IOption;
@@ -337,9 +333,7 @@ export default class Option implements IOption {
 
       const supply: IValue = {
         raw: new BigNumber(result.toString()),
-        humanized: new BigNumber(result.toString()).dividedBy(
-          new BigNumber(10).pow(this.decimals!)
-        ),
+        humanized: humanize(new BigNumber(result.toString()), this.decimals!)
       };
 
       return supply;
@@ -374,9 +368,7 @@ export default class Option implements IOption {
 
       const size: IValue = {
         raw: new BigNumber(result.toString()),
-        humanized: new BigNumber(result.toString()).dividedBy(
-          new BigNumber(10).pow(this.decimals!)
-        ),
+        humanized: humanize(new BigNumber(result.toString()), this.decimals!)
       };
 
       return size;
@@ -406,9 +398,7 @@ export default class Option implements IOption {
 
       const size: IValue = {
         raw: new BigNumber(result.toString()),
-        humanized: new BigNumber(result.toString()).dividedBy(
-          new BigNumber(10).pow(this.decimals!)
-        ),
+        humanized: humanize(new BigNumber(result.toString()), this.decimals!)
       };
 
       return size;
@@ -444,16 +434,12 @@ export default class Option implements IOption {
 
       const SB: IValue = {
         raw: new BigNumber(result[0].toString()),
-        humanized: new BigNumber(result[0].toString()).dividedBy(
-          new BigNumber(10).pow(this.strike!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result[0].toString()), this.strike!.decimals)
       };
 
       const UB: IValue = {
         raw: new BigNumber(result[1].toString()),
-        humanized: new BigNumber(result[1].toString()).dividedBy(
-          new BigNumber(10).pow(this.underlying!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result[1].toString()), this.underlying!.decimals)
       };
 
       return [UB, SB];

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import BigNumber from "bignumber.js";
 import Token from "./token";
 import contracts from "../contracts";
-import { zero } from "../utils";
+import { zero, scaleUp } from "../utils";
 
 import {
   IProvider,
@@ -14,7 +14,7 @@ import {
   Optional,
 } from "@types";
 import { ALLOW_LOGS } from "../constants/globals";
-import { expect } from "../utils";
+import { expect, humanize } from "../utils";
 
 export default class Pool implements IPool {
   /**
@@ -133,9 +133,7 @@ export default class Pool implements IPool {
 
     const IV: IValue = {
       raw: new BigNumber(_.get(properties, "currentIV").toString()),
-      humanized: new BigNumber(
-        _.get(properties, "currentIV").toString()
-      ).dividedBy(new BigNumber(10).pow(18)),
+      humanized: humanize(new BigNumber(_.get(properties, "currentIV").toString()), 18)
     };
 
     return IV;
@@ -152,9 +150,7 @@ export default class Pool implements IPool {
 
     const adjustedIV: IValue = {
       raw: new BigNumber(result.toString()),
-      humanized: new BigNumber(result.toString()).dividedBy(
-        new BigNumber(10).pow(18)
-      ),
+      humanized: humanize(new BigNumber(result.toString()), 18)
     };
 
     return adjustedIV;
@@ -169,9 +165,7 @@ export default class Pool implements IPool {
     expect(this.provider || params.provider, "provider");
 
     try {
-      const sanitized = params.amount.multipliedBy(
-        new BigNumber(10).pow(this.tokenA!.decimals)
-      );
+      const sanitized = scaleUp(params.amount, this.tokenA!.decimals)
       const contract = contracts.instances.pool(
         (this.provider || params.provider)!,
         this.address
@@ -187,23 +181,17 @@ export default class Pool implements IPool {
 
       const value: IValue = {
         raw: new BigNumber(amountBIn.toString()),
-        humanized: new BigNumber(amountBIn.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(amountBIn.toString()), this.tokenB!.decimals)
       };
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA.toString()),
-        humanized: new BigNumber(feesTokenA.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenA!.decimals)
       };
 
       const feesB: IValue = {
         raw: new BigNumber(feesTokenB.toString()),
-        humanized: new BigNumber(feesTokenB.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenB.toString()), this.tokenB!.decimals)
       };
 
       return { value, feesA, feesB };
@@ -222,9 +210,7 @@ export default class Pool implements IPool {
     expect(this.provider || params.provider, "provider");
 
     try {
-      const sanitized = params.amount.multipliedBy(
-        new BigNumber(10).pow(this.tokenA!.decimals)
-      );
+      const sanitized = scaleUp(params.amount, this.tokenA!.decimals);
       const contract = contracts.instances.pool(
         (this.provider || params.provider)!,
         this.address
@@ -240,23 +226,17 @@ export default class Pool implements IPool {
 
       const value: IValue = {
         raw: new BigNumber(amountBOut.toString()),
-        humanized: new BigNumber(amountBOut.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(amountBOut.toString()), this.tokenB!.decimals)
       };
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA.toString()),
-        humanized: new BigNumber(feesTokenA.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenA!.decimals)
       };
 
       const feesB: IValue = {
         raw: new BigNumber(feesTokenB.toString()),
-        humanized: new BigNumber(feesTokenB.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenB.toString()), this.tokenB!.decimals)
       };
 
       return { value, feesA, feesB };
@@ -282,9 +262,7 @@ export default class Pool implements IPool {
 
       const value: IValue = {
         raw: new BigNumber(result.toString()),
-        humanized: new BigNumber(result.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result.toString()), this.tokenB!.decimals)
       };
 
       return { value };
@@ -303,9 +281,7 @@ export default class Pool implements IPool {
     expect(this.provider || params.provider, "provider");
 
     try {
-      const sanitized = params.amount.multipliedBy(
-        new BigNumber(10).pow(this.tokenB!.decimals)
-      );
+      const sanitized = scaleUp(params.amount, this.tokenB!.decimals);
       const contract = contracts.instances.pool(
         (this.provider || params.provider)!,
         this.address
@@ -321,23 +297,17 @@ export default class Pool implements IPool {
 
       const value: IValue = {
         raw: new BigNumber(amountAOut.toString()),
-        humanized: new BigNumber(amountAOut.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber(amountAOut.toString()), this.tokenA!.decimals)
       };
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA.toString()),
-        humanized: new BigNumber(feesTokenA.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenA!.decimals)
       };
 
       const feesB: IValue = {
         raw: new BigNumber(feesTokenB.toString()),
-        humanized: new BigNumber(feesTokenB.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feesTokenB.toString()), this.tokenB!.decimals)
       };
 
       return { value, feesA, feesB };
@@ -364,16 +334,12 @@ export default class Pool implements IPool {
 
       const DBA: IValue = {
         raw: new BigNumber(resultDBA.toString()),
-        humanized: new BigNumber(resultDBA.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber(resultDBA.toString()), this.tokenA!.decimals)
       };
 
       const DBB: IValue = {
         raw: new BigNumber(resultDBB.toString()),
-        humanized: new BigNumber(resultDBB.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(resultDBB.toString()), this.tokenB!.decimals)
       };
 
       return [DBA, DBB];
@@ -409,16 +375,12 @@ export default class Pool implements IPool {
 
       const FBA: IValue = {
         raw: new BigNumber(feeBalanceA.toString()),
-        humanized: new BigNumber(feeBalanceA.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feeBalanceA.toString()), this.tokenA!.decimals)
       };
 
       const FBB: IValue = {
         raw: new BigNumber(feeBalanceB.toString()),
-        humanized: new BigNumber(feeBalanceB.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(feeBalanceB.toString()), this.tokenB!.decimals)
       };
 
       return [FBA, FBB];
@@ -444,15 +406,11 @@ export default class Pool implements IPool {
       const result = await contract.getPoolBalances();
       const TBA: IValue = {
         raw: new BigNumber(result[0].toString()),
-        humanized: new BigNumber(result[0].toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result[0].toString()), this.tokenA!.decimals)
       };
       const TBB: IValue = {
         raw: new BigNumber(result[1].toString()),
-        humanized: new BigNumber(result[1].toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result[1].toString()), this.tokenB!.decimals)
       };
       return [TBA, TBB];
     } catch (error) {
@@ -520,9 +478,7 @@ export default class Pool implements IPool {
 
       const size: IValue = {
         raw: new BigNumber(result.toString()),
-        humanized: new BigNumber(result.toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result.toString()), this.tokenB!.decimals)
       };
 
       return size;
@@ -557,15 +513,11 @@ export default class Pool implements IPool {
 
       const UBA: IValue = {
         raw: new BigNumber(result[0].toString()),
-        humanized: new BigNumber(result[0].toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenA!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result[0].toString()), this.tokenA!.decimals)
       };
       const UBB: IValue = {
         raw: new BigNumber(result[1].toString()),
-        humanized: new BigNumber(result[1].toString()).dividedBy(
-          new BigNumber(10).pow(this.tokenB!.decimals)
-        ),
+        humanized: humanize(new BigNumber(result[1].toString()), this.tokenB!.decimals)
       };
 
       return [UBA, UBB];

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -186,7 +186,7 @@ export default class Pool implements IPool {
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA.toString()),
-        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenA!.decimals)
+        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenB!.decimals)
       };
 
       const feesB: IValue = {
@@ -231,7 +231,7 @@ export default class Pool implements IPool {
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA.toString()),
-        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenA!.decimals)
+        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenB!.decimals)
       };
 
       const feesB: IValue = {
@@ -302,7 +302,7 @@ export default class Pool implements IPool {
 
       const feesA: IValue = {
         raw: new BigNumber(feesTokenA.toString()),
-        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenA!.decimals)
+        humanized: humanize(new BigNumber(feesTokenA.toString()), this.tokenB!.decimals)
       };
 
       const feesB: IValue = {
@@ -375,7 +375,7 @@ export default class Pool implements IPool {
 
       const FBA: IValue = {
         raw: new BigNumber(feeBalanceA.toString()),
-        humanized: humanize(new BigNumber(feeBalanceA.toString()), this.tokenA!.decimals)
+        humanized: humanize(new BigNumber(feeBalanceA.toString()), this.tokenB!.decimals)
       };
 
       const FBB: IValue = {

--- a/src/entities/position.ts
+++ b/src/entities/position.ts
@@ -12,7 +12,7 @@ import {
   IPositionBuilderParams,
 } from "@types";
 
-import { expect } from "../utils";
+import { expect, humanize } from "../utils";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
@@ -115,9 +115,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.premiumPaid!),
-      humanized: new BigNumber(this.premiumPaid!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.premiumPaid!), this.option!.pool!.tokenB!.decimals)
     };
 
     return value;
@@ -131,9 +129,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.premiumReceived!),
-      humanized: new BigNumber(this.premiumReceived!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.premiumReceived!), this.option!.pool!.tokenB!.decimals)
     };
 
     return value;
@@ -147,9 +143,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsBought!),
-      humanized: new BigNumber(this.optionsBought!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsBought!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -163,9 +157,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsSold!),
-      humanized: new BigNumber(this.optionsSold!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsSold!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -179,9 +171,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsResold!),
-      humanized: new BigNumber(this.optionsResold!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsResold!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -195,9 +185,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsMinted!),
-      humanized: new BigNumber(this.optionsMinted!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsMinted!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -211,9 +199,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsUnminted!),
-      humanized: new BigNumber(this.optionsUnminted!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsUnminted!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -227,9 +213,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsExercised!),
-      humanized: new BigNumber(this.optionsExercised!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsExercised!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -243,9 +227,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsSent!),
-      humanized: new BigNumber(this.optionsSent!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsSent!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -259,9 +241,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.optionsReceived!),
-      humanized: new BigNumber(this.optionsReceived!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.optionsReceived!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -274,9 +254,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.underlyingWithdrawn!),
-      humanized: new BigNumber(this.underlyingWithdrawn!).dividedBy(
-        new BigNumber(10).pow(this.option!.underlying!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.underlyingWithdrawn!), this.option!.underlying!.decimals)
     };
 
     return value;
@@ -289,9 +267,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.strikeWithdrawn!),
-      humanized: new BigNumber(this.strikeWithdrawn!).dividedBy(
-        new BigNumber(10).pow(this.option!.strike!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.strikeWithdrawn!), this.option!.strike!.decimals)
     };
 
     return value;
@@ -305,9 +281,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.initialOptionsProvided!),
-      humanized: new BigNumber(this.initialOptionsProvided!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.initialOptionsProvided!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -321,9 +295,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.initialTokensProvided!),
-      humanized: new BigNumber(this.initialTokensProvided!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.initialTokensProvided!), this.option!.pool!.tokenB!.decimals)
     };
 
     return value;
@@ -337,9 +309,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.finalOptionsRemoved!),
-      humanized: new BigNumber(this.finalOptionsRemoved!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.finalOptionsRemoved!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -353,9 +323,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.finalTokensRemoved!),
-      humanized: new BigNumber(this.finalTokensRemoved!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.finalTokensRemoved!), this.option!.pool!.tokenB!.decimals)
     };
 
     return value;
@@ -369,9 +337,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.remainingOptionsProvided!),
-      humanized: new BigNumber(this.remainingOptionsProvided!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenA!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.remainingOptionsProvided!), this.option!.pool!.tokenA!.decimals)
     };
 
     return value;
@@ -385,9 +351,7 @@ export default class Position implements IPosition {
 
     const value: IValue = {
       raw: new BigNumber(this.remainingTokensProvided!),
-      humanized: new BigNumber(this.remainingTokensProvided!).dividedBy(
-        new BigNumber(10).pow(this.option!.pool!.tokenB!.decimals)
-      ),
+      humanized: humanize(new BigNumber(this.remainingTokensProvided!), this.option!.pool!.tokenB!.decimals)
     };
 
     return value;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -80,7 +80,7 @@ export async function getOwner(provider: IProvider): Promise<string> {
  * @param decimals
  * @returns {BigNumber} humanized value
  */
-export function humanize(raw: BigNumber, decimals: number = 18): BigNumber {
+export function humanize(raw: BigNumber, decimals: BigNumber| number = 18): BigNumber {
   return raw.dividedBy(new BigNumber(10).pow(decimals));
 }
 
@@ -124,15 +124,22 @@ export async function getOverrides(
   return overrides;
 }
 
+/**
+ * Multiply numbers by 10^decimals.
+ */
+ export function scaleUp(raw: BigNumber, decimals: BigNumber| number = 18): BigNumber {
+  return raw.multipliedBy(new BigNumber(10).pow(decimals));
+}
+
 const utils = {
   config,
   isNilOrEmptyString,
   attemptAsync,
   zero,
   expect,
-
   getDefaultDeadline,
   getOwner,
   humanize,
+  scaleUp
 };
 export default utils;


### PR DESCRIPTION
Changelog:

- [x] Add `scaleUp` utility
- [x] DRY-ify `humanized` variable calculations
- [x] DRY-ify calculations in `entities/helper.ts` with `scaleUp`
- [x] ~~Fix use tokenA decimals in tokenA amounts~~
- [x] Make "humanize" function accept `BigNumber | number`

Addresses #7, #8 and #9.